### PR TITLE
MAT-7861: Check Pop Description is non-null before adding to HR

### DIFF
--- a/src/main/java/gov/cms/madie/util/HumanReadableUtil.java
+++ b/src/main/java/gov/cms/madie/util/HumanReadableUtil.java
@@ -119,25 +119,24 @@ public class HumanReadableUtil {
   public static String getPopulationDescription(Measure measure, String populationType) {
     StringBuilder sb = new StringBuilder();
     if (CollectionUtils.isNotEmpty(measure.getGroups())) {
-      measure.getGroups().stream()
-          .forEach(
-              group -> {
-                if (CollectionUtils.isNotEmpty(group.getPopulations())) {
-                  group.getPopulations().stream()
-                      .forEach(
-                          population -> {
-                            if (StringUtils.isNotBlank(population.getDefinition())
-                                && populationType.equalsIgnoreCase(population.getName().name())) {
-                              sb.append(population.getDescription() + "\n");
-                            }
-                          });
+      measure.getGroups().forEach(
+        group -> {
+          if (CollectionUtils.isNotEmpty(group.getPopulations())) {
+            group.getPopulations().forEach(
+              population -> {
+                if (StringUtils.isNotBlank(population.getDefinition())
+                    && populationType.equalsIgnoreCase(population.getName().name())
+                    && StringUtils.isNotBlank(population.getDescription())) {
+                  sb.append(population.getDescription()).append("\n");
                 }
               });
+          }
+        });
     }
     if (StringUtils.isBlank(sb.toString())) {
       return "None";
     }
-    return sb.toString();
+    return sb.toString().trim();
   }
 
   public static String getMeasureObservationDescriptions(Measure measure) {

--- a/src/test/java/gov/cms/madie/util/HumanReadableUtilTest.java
+++ b/src/test/java/gov/cms/madie/util/HumanReadableUtilTest.java
@@ -170,6 +170,26 @@ public class HumanReadableUtilTest {
   }
 
   @Test
+  void testGetPopulationDescriptionMultiplePopCriteriaMixedDescriptions() {
+    measure.setGroups(List.of(
+        Group.builder().populations(List.of(Population.builder().definition("definition1").name(PopulationType.INITIAL_POPULATION).description("desc").build())).build(),
+        Group.builder().populations(List.of(Population.builder().definition("definition1").name(PopulationType.INITIAL_POPULATION).description("").build())).build()
+    ));
+    var result = HumanReadableUtil.getPopulationDescription(measure, PopulationType.INITIAL_POPULATION.name());
+    assertThat(result, is(equalTo("desc")));
+  }
+
+  @Test
+  void testGetPopulationDescriptionMultiplePopCriteriaMixedNullDescriptions() {
+    measure.setGroups(List.of(
+        Group.builder().populations(List.of(Population.builder().definition("definition1").name(PopulationType.INITIAL_POPULATION).description("desc").build())).build(),
+        Group.builder().populations(List.of(Population.builder().definition("definition1").name(PopulationType.INITIAL_POPULATION).description(null).build())).build()
+    ));
+    var result = HumanReadableUtil.getPopulationDescription(measure, PopulationType.INITIAL_POPULATION.name());
+    assertThat(result, is(equalTo("desc")));
+  }
+
+  @Test
   void testStratificationDescriptionOutput() {
     Stratification s1 = Stratification.builder().description("G1S1").build();
     Group g1 = Group.builder().stratifications(List.of(s1)).build();


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7861](https://jira.cms.gov/browse/MAT-7861)
(Optional) Related Tickets:

### Summary
If the Population Description is `null`, instead of empty String, the StringBuilder append method will append the literal `"null"`. Check Description is non-null before appending to avoid. (Ref: Help desk MADIE-2059)

This also prevents extra new lines by skipping empty descriptions and trimming the final result. (Ref: Help desk MADIE-2058)

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
