### PR TITLE
MAT-7961: Trim the eCQM Abbr Title when used in an export filename.

### DIFF
--- a/src/main/java/gov/cms/madie/services/PackagingService.java
+++ b/src/main/java/gov/cms/madie/services/PackagingService.java
@@ -41,23 +41,25 @@ public class PackagingService {
     Map<String, byte[]> entries = new HashMap<>();
     for (TranslatedLibrary translatedLibrary : translatedLibraries) {
       String entryName = translatedLibrary.getName() + "-" + translatedLibrary.getVersion();
-      entries.put(resourcesDir + entryName + ".json", translatedLibrary.getElmJson().getBytes());
-      entries.put(resourcesDir + entryName + ".xml", translatedLibrary.getElmXml().getBytes());
-      entries.put(cqlDir + entryName + ".cql", translatedLibrary.getCql().getBytes());
+      entries.put(
+          resourcesDir + entryName.trim() + ".json", translatedLibrary.getElmJson().getBytes());
+      entries.put(
+          resourcesDir + entryName.trim() + ".xml", translatedLibrary.getElmXml().getBytes());
+      entries.put(cqlDir + entryName.trim() + ".cql", translatedLibrary.getCql().getBytes());
     }
     CqlLookups cqlLookups = translationServiceClient.getCqlLookups(qdmMeasure, accessToken);
     final String humanReadable = humanReadableService.generate(measure, cqlLookups);
 
     if (humanReadable != null) {
       entries.put(
-          measure.getEcqmTitle() + "-v" + measure.getVersion() + "-QDM" + ".html",
+          measure.getEcqmTitle().trim() + "-v" + measure.getVersion() + "-QDM" + ".html",
           humanReadable.getBytes());
     }
-      String hqmf = hqmfService.generateHqmf(qdmMeasure, cqlLookups);
-      entries.put(
-          measure.getEcqmTitle() + "-v" + measure.getVersion() + "-QDM" + ".xml", hqmf.getBytes());
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    return new ZipUtility().zipEntries(entries, outputStream);
+    String hqmf = hqmfService.generateHqmf(qdmMeasure, cqlLookups);
+    entries.put(
+        measure.getEcqmTitle().trim() + "-v" + measure.getVersion() + "-QDM" + ".xml",
+        hqmf.getBytes());
+    return new ZipUtility().zipEntries(entries, new ByteArrayOutputStream());
   }
 
   public byte[] createQRDA(QrdaRequestDTO qrdaRequestDTO, String accessToken) {

--- a/src/test/java/gov/cms/madie/services/PackagingServiceTest.java
+++ b/src/test/java/gov/cms/madie/services/PackagingServiceTest.java
@@ -142,13 +142,13 @@ class PackagingServiceTest {
     when(humanReadableService.generate(any(Measure.class), any(CqlLookups.class)))
         .thenReturn("success");
 
-    Mockito.doThrow(new PackagingException("An error occurred that caused the HQMF generation to fail"))
+    Mockito.doThrow(
+            new PackagingException("An error occurred that caused the HQMF generation to fail"))
         .when(hqmfService)
         .generateHqmf(any(QdmMeasure.class), any(CqlLookups.class));
     Exception exception =
         assertThrows(
-                PackagingException.class,
-            () -> packagingService.createMeasurePackage(measure, TOKEN));
+            PackagingException.class, () -> packagingService.createMeasurePackage(measure, TOKEN));
     assertThat(
         exception.getMessage(),
         containsString("An error occurred that caused the HQMF generation to fail"));
@@ -233,5 +233,38 @@ class PackagingServiceTest {
 
     assertThat(new String(qrda), containsString("html/"));
     assertThat(new String(qrda), containsString("2_test.html"));
+  }
+
+  @Test
+  void trimFileNameValues() {
+    QdmMeasure msr = measure.toBuilder().ecqmTitle("   test   ").build();
+    TranslatedLibrary library1 =
+        TranslatedLibrary.builder()
+            .name("Lib one")
+            .version("0.0.000")
+            .elmJson("elm xml")
+            .elmXml("elm xml")
+            .cql("cql")
+            .build();
+    TranslatedLibrary library2 =
+        TranslatedLibrary.builder()
+            .name("Lib two")
+            .version("0.0.001")
+            .elmJson("elm xml")
+            .elmXml("elm xml")
+            .cql("cql")
+            .build();
+    CqlLookups cqlLookups = CqlLookups.builder().build();
+    when(translationServiceClient.getTranslatedLibraries(msr.getCql(), TOKEN))
+        .thenReturn(List.of(library1, library2));
+    when(translationServiceClient.getCqlLookups(any(QdmMeasure.class), anyString()))
+        .thenReturn(CqlLookups.builder().build());
+    when(hqmfService.generateHqmf(msr, cqlLookups)).thenReturn("<hqmf>this is a test hqmf</hqmf>");
+    when(humanReadableService.generate(any(Measure.class), any(CqlLookups.class)))
+        .thenReturn("success");
+    byte[] packageContents = packagingService.createMeasurePackage(msr, TOKEN);
+    String packageString = new String(packageContents);
+    assertThat(packageString, containsString("test-v1.2.003-QDM.html"));
+    assertThat(packageString, containsString("test-v1.2.003-QDM.xml"));
   }
 }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7961](https://jira.cms.gov/browse/MAT-7961)
(Optional) Related Tickets:

### Summary

Trim excess leading and trailing whitespace from the eCQM Abbreviated title when it is used in a filename.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
